### PR TITLE
fixes: Don't kill dhclients and add additionnal nameservers

### DIFF
--- a/tasks/network-settings.yml
+++ b/tasks/network-settings.yml
@@ -4,7 +4,7 @@
     src: nodnsupdate
     dest: /etc/dhcp/dhclient-enter-hooks.d/nodnsupdate
   notify:
-    - kill dhclients
+    # - kill dhclients
     - restart networking service
   when:
   - bind__resolv_conf_configure

--- a/templates/resolv.conf
+++ b/templates/resolv.conf
@@ -14,3 +14,9 @@ nameserver {{ ip }}
 {%     endif %}
 {%   endfor %}
 {% endif %}
+
+{% if bind__additional_nameservers is defined and bind__additional_nameservers is iterable %}
+{%   for ip in bind__additional_nameservers %}
+nameserver {{ ip }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
* Sometimes, dhclients are usefull and don't need to be killed
* Use additional name servers in case of failing default NS