### PR TITLE
Fix: Zone serial number computation

### DIFF
--- a/tasks/bind.yml
+++ b/tasks/bind.yml
@@ -28,11 +28,11 @@
     mode: 0644
   notify: Restart bind9
 
-# This computation assumes delay is less than 100ms between hosts (it's dirty!)
+# This computation assumes delay is less than 10s between hosts (it's dirty!)
 # to propagate same serial number through hosts.
 - name: Compute Serial number
   set_fact:
-    bind__serialnum: "{{ ( ansible_date_time.epoch|int / 100 )|int * 200 }}"
+    bind__serialnum: "{{ ( ansible_date_time.epoch|int / 10 )|int * 20 }}"
 
 - name: bind internal domain zone
   template:


### PR DESCRIPTION
Serial num is now computed on a 10s basis
Fix #13 