### PR TITLE
Fix: entry may be a single item

### DIFF
--- a/tasks/conf-server.yml
+++ b/tasks/conf-server.yml
@@ -149,7 +149,7 @@
 - name: bind known domains reverse zones (may contain internal network) serial
   template:
     src: db.known.rev.serial
-    dest: "{{ bind__zone_directory }}/db.{{ entry.name|replace('/', '-') }}.rev.serial"
+    dest: "{{ bind__zone_directory }}/db.{{ entry.item|replace('/', '-') }}.rev.serial"
     mode: 0644
   loop: "{{ known_rev.results|from_yaml|list }}"
   loop_control:

--- a/templates/db.known.rev.serial
+++ b/templates/db.known.rev.serial
@@ -1,4 +1,4 @@
-; BIND serial file for {{ entry.name }}
+; BIND serial file for {{ entry.item }}
 $TTL    {{ bind__default_ttl }}
 @   IN  SOA {{ ansible_hostname }}.{{ bind__internal_domain }}. root.{{ bind__internal_domain }}. (
             {{ bind__serialnum }}     ; Serial


### PR DESCRIPTION
This looping mechanism should work only on single items, not on dicts