### PR TITLE
Fix: Avoid network restart during configuration

### DIFF
--- a/tasks/conf-client.yml
+++ b/tasks/conf-client.yml
@@ -3,9 +3,9 @@
   copy:
     src: nodnsupdate
     dest: /etc/dhcp/dhclient-enter-hooks.d/nodnsupdate
-  notify:
-    # - kill dhclients
-    - restart networking service
+  # notify:
+  #   # - kill dhclients
+  #   - restart networking service
   when:
   - bind__resolv_conf_configure
 


### PR DESCRIPTION
Because network can be not totally configured during this step, we
should avoid to restart it