### PR TITLE
Feat: Use variable for URL checker

### DIFF
--- a/templates/ip_check
+++ b/templates/ip_check
@@ -3,7 +3,7 @@
 
 set -e
 old_ip=$(dig +short a {{ item.domain }} @{{ item.ns }})
-new_ip=$(curl -s ipconfig.io)
+new_ip=$(curl -s {{ item.ipconfig_url }})
 if [ "$old_ip" != "$new_ip" ]
 then
     echo "IP changed: new IP=${new_ip}"


### PR DESCRIPTION
The IP checker should be a variable instead of hard-coded value