### PR TITLE
Fix: Change ipaddr syntax

### DIFF
--- a/templates/db.known.rev
+++ b/templates/db.known.rev
@@ -11,12 +11,12 @@ $INCLUDE db.{{ item|replace('/', '-') }}.rev.serial
 ; DYNAMIC HOSTNAME RECORDS
 {% for server in groups[bind__dynamic_group|default('all')]|sort %}
 {%   if 'ansible_all_ipv4_addresses' in hostvars[server].keys() %}
-{%     for ip in hostvars[server]['ansible_all_ipv4_addresses']|ipaddr(item) %}
+{%     for ip in hostvars[server]['ansible_all_ipv4_addresses']|ansible.utils.ipaddr(item) %}
 {%       set _ = defined.append(ip.split('.')[3]) %}
 {{ '%-3s'|format(ip.split('.')[3]) }} IN PTR {{ hostvars[server]['ansible_hostname'] }}.{{ bind__internal_domain }}.
 {%     endfor %}
 {%   elif bind__static_ips is defined and server.split('.')[0] in bind__static_ips.keys() %}
-{%     if bind__static_ips[server.split('.')[0]]|ipaddr(item) %}
+{%     if bind__static_ips[server.split('.')[0]]|ansible.utils.ipaddr(item) %}
 {%       set _ = defined.append(bind__static_ips[server.split('.')[0]].split('.')[3]) %}
 {{ '%-3s'|format(bind__static_ips[server.split('.')[0]].split('.')[3]) }} IN PTR {{ server }}.
 {%     endif %}
@@ -28,7 +28,7 @@ $INCLUDE db.{{ item|replace('/', '-') }}.rev.serial
 
 ; STATIC REVERSE RECORDS
 {%   for host, ip in bind__static_reverse|dictsort %}
-{%     if ip | ipaddr(item) %}
+{%     if ip | ansible.utils.ipaddr(item) %}
 {%       if ip.split('.')[3] not in defined %}
 {%         set _ = defined.append(ip.split('.')[3]) %}
 {{ '%-3s'|format(ip.split('.')[3]) }} IN PTR {{ host }}.{{ bind__internal_domain }}.
@@ -40,7 +40,7 @@ $INCLUDE db.{{ item|replace('/', '-') }}.rev.serial
 
 ; STATIC REVERSE FROM STATIC IP RECORDS
 {%   for host, ip in bind__static_ips|dictsort %}
-{%     if ip | ipaddr(item) %}
+{%     if ip | ansible.utils.ipaddr(item) %}
 {%       if ip.split('.')[3] not in defined %}
 {%         set _ = defined.append(ip.split('.')[3]) %}
 {{ '%-3s'|format(ip.split('.')[3]) }} IN PTR {{ host }}.{{ bind__internal_domain }}.

--- a/templates/db.rev
+++ b/templates/db.rev
@@ -10,11 +10,11 @@ $INCLUDE db.{{ bind__internal_network|replace('/', '-') }}.rev.serial
 ; DYNAMIC HOSTNAME RECORDS
 {% for server in groups[bind__dynamic_group|default('all')]|sort %}
 {%   if 'ansible_all_ipv4_addresses' in hostvars[server].keys() %}
-{%     for ip in hostvars[server]['ansible_all_ipv4_addresses']|ipaddr(bind__internal_network) %}
+{%     for ip in hostvars[server]['ansible_all_ipv4_addresses']|ansible.utils.ipaddr(bind__internal_network) %}
 {{ '%-3s'|format(ip.split('.')[3]) }} IN PTR {{ hostvars[server]['ansible_hostname'] }}.{{ bind__internal_domain }}.
 {%     endfor %}
 {%   elif bind__static_ips is defined and server.split('.')[0] in bind__static_ips.keys() %}
-{%     if bind__static_ips[server.split('.')[0]]|ipaddr(bind__internal_network) %}
+{%     if bind__static_ips[server.split('.')[0]]|ansible.utils.ipaddr(bind__internal_network) %}
 {{ '%-3s'|format(bind__static_ips[server.split('.')[0]].split('.')[3]) }} IN PTR {{ server }}
 {%     endif %}
 {%   else %}
@@ -25,7 +25,7 @@ $INCLUDE db.{{ bind__internal_network|replace('/', '-') }}.rev.serial
 
 ; STATIC REVERSE RECORDS
 {%   for host, ip in bind__static_reverse|dictsort %}
-{%     if ip | ipaddr(bind__internal_network) %}
+{%     if ip | ansible.utils.ipaddr(bind__internal_network) %}
 {{ '%-3s'|format(ip.split('.')[3]) }} IN PTR {{ host }}.{{ bind__internal_domain }}.
 {%     endif %}
 {%   endfor %}

--- a/templates/db.zone
+++ b/templates/db.zone
@@ -27,7 +27,7 @@ $INCLUDE db.{{ bind__internal_domain }}.serial
 {% for host in groups[bind__dynamic_group]|sort %}
 {%   if 'ansible_hostname' in hostvars[host] and hostvars[host]['ansible_hostname'] not in declared %}
 {%     if 'ansible_all_ipv4_addresses' in hostvars[host].keys() %}
-{%       for ip in hostvars[host]['ansible_all_ipv4_addresses']|ipaddr(bind__internal_network) %}
+{%       for ip in hostvars[host]['ansible_all_ipv4_addresses']|ansible.utils.ipaddr(bind__internal_network) %}
 {{ '%-24s'|format(hostvars[host]['ansible_hostname']) }} IN A {{ ip }}
 {%         set _ = declared.append(hostvars[host]['ansible_hostname']) %}
 {%       endfor %}

--- a/templates/etc_hosts
+++ b/templates/etc_hosts
@@ -9,7 +9,7 @@ ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
 
 {% if bind__internal_network %}
-{%   for ip in hostvars[inventory_hostname]['ansible_all_ipv4_addresses']|ipaddr(network_internal_network|default(bind__internal_network)) %}
+{%   for ip in hostvars[inventory_hostname]['ansible_all_ipv4_addresses']|ansible.utils.ipaddr(network_internal_network|default(bind__internal_network)) %}
 {{ ip }} {{ ansible_hostname }}.{{ bind__internal_domain }} {{ ansible_hostname }}
 {%   endfor %}
 {% endif %}

--- a/templates/resolv.conf
+++ b/templates/resolv.conf
@@ -8,7 +8,7 @@ nameserver {{ ip }}
 {% else %}
 {%   for nameserver in groups['nameserver']|sort %}
 {%     if nameserver in groups[bind__dynamic_group] %}
-{%       for ip in hostvars[nameserver]['ansible_all_ipv4_addresses']|ipaddr(bind__internal_network) %}
+{%       for ip in hostvars[nameserver]['ansible_all_ipv4_addresses']|ansible.utils.ipaddr(bind__internal_network) %}
 nameserver {{ ip }}
 {%       endfor %}
 {%     endif %}


### PR DESCRIPTION
Because it's now a part of ansible.utils galaxy, filter syntax is changed